### PR TITLE
Report error in port binding

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,9 @@ var PhantomJSDriver = {
       if (stream.search('GhostDriver - Main - running') !== -1) {
         deferred.resolve();
       }
+      else if (stream.search('Could not start Ghost Driver') !== -1) {
+        deferred.reject('Could not start Ghost Driver');
+      }
     });
     return deferred.promise;
   },

--- a/test/index_TEST.js
+++ b/test/index_TEST.js
@@ -9,4 +9,20 @@ describe('dalek-browser-phantomjs', function() {
     expect(PhantomJSDriver.port).to.equal(9001);
   });
 
+  it('should fail on busy port', function(done){
+    PhantomJSDriver.port = 80;
+    PhantomJSDriver.launch()
+      .fail(function() {
+        done();
+      });
+  });
+
+  it('should launch on port 9006', function(done){
+    PhantomJSDriver.port = 9006;
+    PhantomJSDriver.launch()
+      .then(function() {
+        done();
+      });
+  });
+
 });


### PR DESCRIPTION
A step in fixing #1 — reject the promise for the browser if GhostDriver is unable to start.
Needs detecting on the outside to inform the reporter.
