### PR TITLE
chore(dependencies): less strict version constrain for phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PhantomJS binding for DalekJS",
   "main": "./index.js",
   "dependencies": {
-    "phantomjs": "1.9.12",
+    "phantomjs": "1.9.x",
     "q": "1.1.2",
     "portscanner": "1.0.0"
   },


### PR DESCRIPTION
as suggested in #9 